### PR TITLE
FIX: avoid using return in discourse event block

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -63,11 +63,12 @@ load File.expand_path('../app/models/explicit_content_setting.rb', __FILE__)
 
 after_initialize do
   on(:before_upload_creation) do |file, is_image|
-    return if !is_image
-    annotator = ::DiscourseImageFilter::ImageUploadAnnotator.new(file.path)
-    violations = annotator.detect_violations
-    if(violations.present?)
-      raise StandardError.new(I18n.t('content_violation_error', violations: violations.to_a*", "))
+    if is_image
+      annotator = ::DiscourseImageFilter::ImageUploadAnnotator.new(file.path)
+      violations = annotator.detect_violations
+      if(violations.present?)
+        raise StandardError.new(I18n.t('content_violation_error', violations: violations.to_a*", "))
+      end
     end
   end
 end


### PR DESCRIPTION
Using `return` inside the `on` block causes the control to return from its parent context too, it looks. Avoid using `return` in the `DiscourseEvent.on` or `on` blocks.